### PR TITLE
fix(deps): pin tslib to allow install on angular 17

### DIFF
--- a/libs/ng-morph/package.json
+++ b/libs/ng-morph/package.json
@@ -19,7 +19,8 @@
         "jsonc-parser": "3.2.0",
         "minimatch": "9.0.3",
         "multimatch": "6.0.0",
-        "ts-morph": "20.0.0"
+        "ts-morph": "20.0.0",
+        "tslib": "2.6.2"
     },
     "peerDependencies": {
         "@angular-devkit/core": ">=11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,8 @@
                 "jsonc-parser": "3.2.0",
                 "minimatch": "9.0.3",
                 "multimatch": "6.0.0",
-                "ts-morph": "20.0.0"
+                "ts-morph": "20.0.0",
+                "tslib": "2.6.2"
             },
             "peerDependencies": {
                 "@angular-devkit/core": ">=11.0.0",
@@ -26075,8 +26076,7 @@
         "node_modules/tslib": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -40312,7 +40312,8 @@
                 "jsonc-parser": "3.2.0",
                 "minimatch": "9.0.3",
                 "multimatch": "6.0.0",
-                "ts-morph": "20.0.0"
+                "ts-morph": "20.0.0",
+                "tslib": "2.6.2"
             }
         },
         "ngx-highlightjs": {
@@ -46173,8 +46174,7 @@
         "tslib": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "tsutils": {
             "version": "3.21.0",


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

tslib 2.5.3 added automaticly to peerDependencies of ng-morph and prevent to install it on angular 17 on modern peer resolution

## What is the new behaviour?

tslib pinned in package dependencies itself like in material or angular/universal