### PR TITLE
fix: release and loose package tslib dep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
       - uses: taiga-family/ci/actions/setup/node@v1.39.1
       - name: release
-        run: npx nx release ng-morph
+        run: npm run release
         continue-on-error: true
         env:
           CI: true

--- a/libs/ng-morph/package.json
+++ b/libs/ng-morph/package.json
@@ -20,7 +20,7 @@
         "minimatch": "9.0.3",
         "multimatch": "6.0.0",
         "ts-morph": "20.0.0",
-        "tslib": "2.6.2"
+        "tslib": "^2.6.2"
     },
     "peerDependencies": {
         "@angular-devkit/core": ">=11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
                 "minimatch": "9.0.3",
                 "multimatch": "6.0.0",
                 "ts-morph": "20.0.0",
-                "tslib": "2.6.2"
+                "tslib": "^2.6.2"
             },
             "peerDependencies": {
                 "@angular-devkit/core": ">=11.0.0",
@@ -40313,7 +40313,7 @@
                 "minimatch": "9.0.3",
                 "multimatch": "6.0.0",
                 "ts-morph": "20.0.0",
-                "tslib": "2.6.2"
+                "tslib": "^2.6.2"
             }
         },
         "ngx-highlightjs": {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

nx 17 introduce nx release command so 
```
nx release ng-morph
```
would not work

## What is the new behaviour?

1) use npm run release to trigger release target instead
2) loose tslib dep to ^2.6.2 in ng-morph package
