### PR TITLE
fix: `isStandaloneComponent` incorrectly returns `false` for default-standalone components (Angular 19+ behavior)

### DIFF
--- a/libs/ng-morph/src/ng/helpers/is-standalone-component.ts
+++ b/libs/ng-morph/src/ng/helpers/is-standalone-component.ts
@@ -10,13 +10,13 @@ export function isStandaloneComponent(component: ClassDeclaration): boolean {
     const [metadata] = decorator.getArguments();
 
     if (!Node.isObjectLiteralExpression(metadata)) {
-        return false;
+        return true;
     }
 
     const property = metadata.getProperty('standalone');
 
     if (!Node.isPropertyAssignment(property)) {
-        return false;
+        return true;
     }
 
     return property.getInitializer()?.getText() === 'true';


### PR DESCRIPTION
https://github.com/taiga-family/ng-morph/blob/48914dec25363cbe387ebf9abee67db5b2358338/libs/ng-morph/package.json#L34-L35