### PR TITLE
fix: preserve negative globs and recursive directory traversal

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -2,5 +2,5 @@
     "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/master/cspell.schema.json",
     "import": ["@taiga-ui/cspell-config/cspell.config.js"],
     "files": ["*/*.*"],
-    "ignoreWords": ["subdirs", "renameable", "decoratable"]
+    "ignoreWords": ["subdirs", "renameable", "decoratable", "extglob"]
 }

--- a/libs/ng-morph/src/project/create-project.ts
+++ b/libs/ng-morph/src/project/create-project.ts
@@ -3,7 +3,7 @@ import {join} from 'node:path';
 import {type Tree} from '@angular-devkit/schematics';
 
 import {coerceArray} from '../utils/coerce-array';
-import {type Pattern} from '../utils/pattern';
+import {isNegativeGlobPattern, type Pattern} from '../utils/pattern';
 import {NgCliProject} from './ng-cli-project';
 
 export function createProject(
@@ -14,9 +14,20 @@ export function createProject(
     const project = new NgCliProject({host});
 
     project.addSourceFilesAtPaths(
-        coerceArray(pattern).map((glob) =>
-            project.getFileSystem().fs.resolve(join(rootPath, glob)),
-        ),
+        coerceArray(pattern).map((glob) => {
+            const isNegativeGlob = isNegativeGlobPattern(glob);
+            const patternWithoutNegativeMarker = isNegativeGlob ? glob.slice(1) : glob;
+
+            const patternWithRootPath = patternWithoutNegativeMarker.startsWith('/')
+                ? patternWithoutNegativeMarker
+                : join(rootPath, patternWithoutNegativeMarker);
+
+            const resolvedPattern = project
+                .getFileSystem()
+                .fs.resolve(patternWithRootPath);
+
+            return isNegativeGlob ? `!${resolvedPattern}` : resolvedPattern;
+        }),
     );
 
     return project;

--- a/libs/ng-morph/src/project/file-system.ts
+++ b/libs/ng-morph/src/project/file-system.ts
@@ -12,6 +12,7 @@ import {basename, join} from 'node:path';
 import {minimatch} from 'minimatch';
 import {type FileSystemHost, type RuntimeDirEntry} from 'ts-morph';
 
+import {isNegativeGlobPattern} from '../utils/pattern';
 import {type DevkitFileSystem} from './devkit-file-system';
 import {type UpdateRecorder} from './update-recorder';
 
@@ -151,7 +152,7 @@ export class NgCliFileSystem implements FileSystemHost {
         return allFiles.filter((file) =>
             (patterns as string[]).reduce<boolean>(
                 (matched, pattern) =>
-                    pattern.startsWith('!')
+                    isNegativeGlobPattern(pattern)
                         ? matched && !minimatch(file, pattern.slice(1))
                         : matched || minimatch(file, pattern),
                 false,
@@ -186,14 +187,14 @@ export class NgCliFileSystem implements FileSystemHost {
 
         return directories
             .map((name) => ({
-                name,
+                name: join(dirPath, name),
                 isFile: false,
                 isDirectory: true,
                 isSymlink: false,
             }))
             .concat(
                 files.map((name) => ({
-                    name,
+                    name: join(dirPath, name),
                     isFile: true,
                     isDirectory: false,
                     isSymlink: false,

--- a/libs/ng-morph/src/utils/pattern.ts
+++ b/libs/ng-morph/src/utils/pattern.ts
@@ -1,1 +1,5 @@
 export type Pattern = string[] | string;
+
+export function isNegativeGlobPattern(pattern: string): boolean {
+    return pattern.startsWith('!') && !pattern.startsWith('!(');
+}

--- a/libs/ng-morph/tests/get-source-files.spec.ts
+++ b/libs/ng-morph/tests/get-source-files.spec.ts
@@ -5,9 +5,76 @@ import {
     createProject,
     createSourceFile,
     getSourceFiles,
+    type Pattern,
     resetActiveProject,
     setActiveProject,
 } from 'ng-morph';
+
+const TAIGA_EXCLUDE_DIRECTORIES = [
+    'e2e',
+    'scripts',
+    'dist',
+    'node_modules',
+    'coverage',
+    'dll',
+    'tmp',
+    '__build__',
+    'allure-results',
+    '.rpt2_cache',
+    '.husky',
+    '.vscode',
+    '.idea',
+    '.github',
+    '.gitlab',
+    '.devplatform',
+    '.angular',
+    '.tmp',
+    '.nx',
+] as const;
+
+const TAIGA_EXCLUDE_FILE_PATTERNS = [
+    '*__name@dasherize__*',
+    '*__name@camelize__*',
+    '*__name@underscore__*',
+    '*.d',
+] as const;
+
+const TAIGA_STYLE_EXTENSIONS = '{less,sass,scss,css}';
+const TAIGA_ALL_EXTENSIONS = '{html,ts,less,sass,scss,css,json}';
+
+const TAIGA_EXCLUDE_DIRECTORY_PATTERNS = TAIGA_EXCLUDE_DIRECTORIES.map(
+    (directory) => `!**/${directory}/**`,
+);
+
+const TAIGA_ALL_STYLE_FILES: Pattern = [
+    `**/*.${TAIGA_STYLE_EXTENSIONS}`,
+    ...TAIGA_EXCLUDE_DIRECTORY_PATTERNS,
+    ...TAIGA_EXCLUDE_FILE_PATTERNS.map(
+        (filePattern) => `!**/${filePattern}.${TAIGA_STYLE_EXTENSIONS}`,
+    ),
+];
+
+const TAIGA_ALL_TS_FILES: Pattern = [
+    '**/*.ts',
+    ...TAIGA_EXCLUDE_DIRECTORY_PATTERNS,
+    ...TAIGA_EXCLUDE_FILE_PATTERNS.map((filePattern) => `!**/${filePattern}.ts`),
+];
+
+const TAIGA_ALL_FILES: Pattern = [
+    `**/*.${TAIGA_ALL_EXTENSIONS}`,
+    ...TAIGA_EXCLUDE_DIRECTORY_PATTERNS,
+    ...TAIGA_EXCLUDE_FILE_PATTERNS.map(
+        (filePattern) => `!**/${filePattern}.${TAIGA_ALL_EXTENSIONS}`,
+    ),
+];
+
+const TAIGA_PROJECT_JSON_FILES: Pattern = [
+    'project.json',
+    'angular.json',
+    '**/project.json',
+    '**/angular.json',
+    ...TAIGA_EXCLUDE_DIRECTORY_PATTERNS,
+];
 
 describe('getSourceFiles', () => {
     let host: UnitTestTree;
@@ -38,6 +105,175 @@ describe('getSourceFiles', () => {
         const sourceFiles = getSourceFiles('some/test.ts');
 
         expect(sourceFiles.length).toBe(1);
+    });
+
+    it('should preserve negative glob patterns when creating project from root path', () => {
+        host.create('/some/test.ts', '');
+        host.create('/some/path/test.ts', '');
+        host.create('/some/coverage/test.ts', '');
+
+        setActiveProject(createProject(host, '/some', ['**/*.ts', '!**/coverage/**']));
+
+        expect(
+            getSourceFiles('**/*.ts')
+                .map((file) => file.getFilePath())
+                .sort(),
+        ).toEqual(['/some/path/test.ts', '/some/test.ts']);
+    });
+
+    it('should preserve absolute glob patterns when creating project from root path', () => {
+        host.create('/some/test.ts', '');
+        host.create('/some/path/test.ts', '');
+        host.create('/some/coverage/test.ts', '');
+
+        setActiveProject(createProject(host, '/some', ['/some/**/*.ts']));
+
+        expect(
+            getSourceFiles('**/*.ts')
+                .map((file) => file.getFilePath())
+                .sort(),
+        ).toEqual(['/some/coverage/test.ts', '/some/path/test.ts', '/some/test.ts']);
+    });
+
+    it('should preserve absolute negative glob patterns when creating project from root path', () => {
+        host.create('/some/test.ts', '');
+        host.create('/some/path/test.ts', '');
+        host.create('/some/coverage/test.ts', '');
+
+        setActiveProject(createProject(host, '/some', ['**/*.ts', '!/some/coverage/**']));
+
+        expect(
+            getSourceFiles('**/*.ts')
+                .map((file) => file.getFilePath())
+                .sort(),
+        ).toEqual(['/some/path/test.ts', '/some/test.ts']);
+    });
+
+    it('should treat extglob patterns as positive patterns', () => {
+        host.create('/test.ts', '');
+        host.create('/some/test.ts', '');
+        host.create('/some/path/test.ts', '');
+        host.create('/coverage/test.ts', '');
+
+        const project = createProject(host, '/', []);
+
+        const filePaths = project
+            .getFileSystem()
+            .globSync(['!(coverage)/**/*.ts'])
+            .sort();
+
+        expect(filePaths).toEqual([
+            '/coverage/test.ts',
+            '/some/path/test.ts',
+            '/some/test.ts',
+            '/test.ts',
+        ]);
+    });
+
+    it('should recursively add directories with repeated names', () => {
+        host.create('/abc/def/abc/test.ts', '');
+
+        const project = createProject(host, '/', []);
+
+        project.addDirectoryAtPath('/abc', {recursive: true});
+
+        expect(
+            project
+                .getDirectoryOrThrow('/abc')
+                .getDescendantDirectories()
+                .map((directory) => directory.getPath())
+                .sort(),
+        ).toEqual(['/abc/def', '/abc/def/abc']);
+    });
+
+    describe('Taiga-like glob patterns', () => {
+        const projectRoot = '/workspace';
+
+        it('should support TypeScript files with nested excluded directories', () => {
+            host.create('/workspace/src/app.ts', '');
+            host.create('/workspace/libs/lib-a/src/index.ts', '');
+            host.create('/workspace/libs/lib-a/coverage/generated.ts', '');
+            host.create('/workspace/libs/lib-a/node_modules/pkg/index.ts', '');
+            host.create('/workspace/dist/out.ts', '');
+            host.create('/workspace/src/input__name@dasherize__.ts', '');
+            host.create('/workspace/src/model.d.ts', '');
+
+            setActiveProject(createProject(host, projectRoot, TAIGA_ALL_TS_FILES));
+
+            expect(
+                getSourceFiles('**/*.ts')
+                    .map((file) => file.getFilePath())
+                    .sort(),
+            ).toEqual(['/workspace/libs/lib-a/src/index.ts', '/workspace/src/app.ts']);
+        });
+
+        it('should support style files with nested excluded directories', () => {
+            host.create('/workspace/src/app.less', '');
+            host.create('/workspace/libs/lib-a/src/card.scss', '');
+            host.create('/workspace/libs/lib-a/coverage/generated.css', '');
+            host.create('/workspace/libs/lib-a/.nx/cache.css', '');
+            host.create('/workspace/tmp/temp.sass', '');
+            host.create('/workspace/src/input__name@camelize__.scss', '');
+
+            const project = createProject(host, projectRoot, TAIGA_ALL_STYLE_FILES);
+
+            expect(
+                project
+                    .getSourceFiles()
+                    .map((file) => file.getFilePath())
+                    .sort(),
+            ).toEqual(['/workspace/libs/lib-a/src/card.scss', '/workspace/src/app.less']);
+        });
+
+        it('should support all migration files with nested excluded directories', () => {
+            host.create('/workspace/src/app.html', '');
+            host.create('/workspace/src/app.ts', '');
+            host.create('/workspace/src/app.less', '');
+            host.create('/workspace/src/config.json', '');
+            host.create('/workspace/libs/lib-a/coverage/report.html', '');
+            host.create('/workspace/libs/lib-a/.angular/cache.json', '');
+            host.create('/workspace/libs/lib-a/node_modules/pkg/index.ts', '');
+            host.create('/workspace/src/input__name@underscore__.html', '');
+            host.create('/workspace/src/model.d.ts', '');
+
+            const project = createProject(host, projectRoot, TAIGA_ALL_FILES);
+
+            expect(
+                project
+                    .getSourceFiles()
+                    .map((file) => file.getFilePath())
+                    .sort(),
+            ).toEqual([
+                '/workspace/src/app.html',
+                '/workspace/src/app.less',
+                '/workspace/src/app.ts',
+                '/workspace/src/config.json',
+            ]);
+        });
+
+        it('should support project json files with nested excluded directories', () => {
+            host.create('/workspace/project.json', '');
+            host.create('/workspace/angular.json', '');
+            host.create('/workspace/libs/lib-a/project.json', '');
+            host.create('/workspace/libs/lib-b/angular.json', '');
+            host.create('/workspace/libs/lib-a/coverage/project.json', '');
+            host.create('/workspace/libs/lib-a/.nx/project.json', '');
+            host.create('/workspace/dist/project.json', '');
+
+            const project = createProject(host, projectRoot, TAIGA_PROJECT_JSON_FILES);
+
+            expect(
+                project
+                    .getSourceFiles()
+                    .map((file) => file.getFilePath())
+                    .sort(),
+            ).toEqual([
+                '/workspace/angular.json',
+                '/workspace/libs/lib-a/project.json',
+                '/workspace/libs/lib-b/angular.json',
+                '/workspace/project.json',
+            ]);
+        });
     });
 
     afterEach(() => {


### PR DESCRIPTION
Fixes https://github.com/taiga-family/taiga-ui/issues/14248
Fixes https://github.com/taiga-family/ng-morph/issues/1216
Fixes https://github.com/taiga-family/ng-morph/issues/1029

Fixed `createProject` glob normalization so negative glob patterns keep the leading `!` after being resolved against `rootPath`.

Before this change, a pattern like:

```ts
createProject(tree, projectRoot(), ['**/*.ts', '!**/coverage/**']);
```

could be normalized into a non-negative path-like pattern, so excluded files were still included.

This also avoids treating extglob patterns like `!(coverage)/**/*.ts` as negative globs.

### Why

Taiga UI migrations need to exclude generated folders nested anywhere in the workspace, for example:

```
libs/lib-a/coverage/**
apps/app-a/dist/**
projects/foo/node_modules/**
```

This requires real negative globs such as:

```
'!**/coverage/**'
'!**/dist/**'
'!**/node_modules/**'
```

### Taiga UI Follow-Up

After this fix lands in ng-morph, Taiga UI should update file-globs.ts.

Current patterns like:

```ts
`!(${EXCLUDE_DIRECTORIES})/**/!(${EXCLUDE_FILE_PATTERNS}).ts`
```

only exclude directories when they are the first path segment. They do not exclude nested directories like:

```
libs/lib-a/coverage/test.ts
```

Taiga should switch to positive include patterns plus negative exclude patterns, for example:

```ts
const EXCLUDE_DIRECTORY_PATTERNS = EXCLUDE_DIRECTORIES.map(
    (directory) => `!**/${directory}/**`,
);

export const ALL_TS_FILES: Pattern = [
    '**/*.ts',
    ...EXCLUDE_DIRECTORY_PATTERNS,
    '!**/*.d.ts',
    '!**/*__name@dasherize__*.ts',
    '!**/*__name@camelize__*.ts',
    '!**/*__name@underscore__*.ts',
];
```

Same should be applied to ALL_STYLE_FILES, ALL_FILES, and PROJECT_JSON_FILES.

### Recursive directory traversal

This PR also fixes recursive directory traversal for virtual file system entries with repeated directory names, such as `abc/def/abc`.

`ts-morph` expects `FileSystemHost.readDirSync` entries to contain full child paths. `NgCliFileSystem` previously returned only child names from the Angular DevKit tree, so recursive directory traversal could resolve nested folders to the wrong root-level paths and fail to discover descendants correctly.

Now `readDirSync` returns paths joined with the requested directory path, matching the `ts-morph` file system contract.

